### PR TITLE
bugfix for duplicate exports in Graphs and LightGraphs

### DIFF
--- a/src/TikzGraphs.jl
+++ b/src/TikzGraphs.jl
@@ -94,13 +94,13 @@ plot(g::LightGraphs.SimpleGraph, labels::Vector{String}) = plot(g, Layered(), la
 function plotHelper(g::LightGraphs.SimpleGraph, libraryname::String, layoutname::String, options::String)
   o = IOBuffer()
   println(o, "\\graph [$layoutname, $options] {")
-  for e in edges(g)
+  for e in LightGraphs.edges(g)
     a = src(e)
     b = dst(e)
     println(o, "$a -> $b;")
   end
   # include isolated nodes
-  for v in vertices(g)
+  for v in LightGraphs.vertices(g)
     if indegree(g, v) == 0 && outdegree(g, v) == 0
       println(o, "$v;")
     end
@@ -113,7 +113,7 @@ end
 function plotHelper{T<:String}(g::LightGraphs.SimpleGraph, libraryname::String, layoutname::String, options::String, labels::Vector{T})
   o = IOBuffer()
   println(o, "\\graph [$layoutname, $options] {")
-  for e in edges(g)
+  for e in LightGraphs.edges(g)
     a = src(e)
     b = dst(e)
     println(o, "\"$(labels[a])\" -> \"$(labels[b])\";")


### PR DESCRIPTION
This fixes the issue identified in https://github.com/sisl/TikzGraphs.jl/pull/1#issuecomment-125835494 - I've successfully installed TeX and can report that I've created a PDF containing a random DiGraph.