### PR TITLE
Use relative paths instead of Pkg.dir()

### DIFF
--- a/src/TikzGraphs.jl
+++ b/src/TikzGraphs.jl
@@ -2,7 +2,7 @@ module TikzGraphs
 
 export plot, Layouts
 
-preamble = readall(joinpath(Pkg.dir("TikzGraphs"), "src", "preamble.tex"))
+preamble = readall(joinpath(dirname(@__FILE__), "..", "src", "preamble.tex"))
 
 using TikzPictures
 using Graphs


### PR DESCRIPTION
Pkg.dir() won't work if package is installed outside the standard package location but available in the LOAD_PATH, e.g. on JuliaBox.
Using relative paths avoids this issue while accessing other files in the package. See https://github.com/JuliaLang/julia/issues/8679.